### PR TITLE
refactor: axios から fetch に移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@book000/node-utils": "1.24.123",
     "@types/jest": "30.0.0",
     "@types/node": "24.12.2",
-    "axios": "1.15.0",
     "date-fns": "4.1.0",
     "eslint": "10.2.0",
     "eslint-config-standard": "17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
-      axios:
-        specifier: 1.15.0
-        version: 1.15.0
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
@@ -916,9 +913,6 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -3725,14 +3719,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axios@1.14.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1,6 +1,5 @@
 import { Configuration } from './config'
 import { setInterval } from 'node:timers/promises'
-import axios from 'axios'
 import { Notified } from './notified'
 import { Utils } from './utils'
 import { Discord, DiscordEmbed, Logger } from '@book000/node-utils'
@@ -54,14 +53,12 @@ export class Crawler {
     const logger = Logger.configure('Crawler.run')
     logger.info('🔍 Fetching changelog')
 
-    const response = await axios.get<string>(this.url, {
-      validateStatus: () => true,
-    })
-    if (response.status !== 200) {
-      logger.error(`❌ Failed to fetch changelog: ${response.status}`)
+    const res = await fetch(this.url)
+    if (!res.ok) {
+      logger.error(`❌ Failed to fetch changelog: ${res.status}`)
       return
     }
-    const body = response.data
+    const body = await res.text()
     if (!body) {
       logger.error('❌ Failed to fetch changelog')
       return

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -53,7 +53,13 @@ export class Crawler {
     const logger = Logger.configure('Crawler.run')
     logger.info('🔍 Fetching changelog')
 
-    const res = await fetch(this.url)
+    let res: Response
+    try {
+      res = await fetch(this.url)
+    } catch (error) {
+      logger.error(`❌ Failed to fetch changelog: ${(error as Error).message}`)
+      return
+    }
     if (!res.ok) {
       logger.error(`❌ Failed to fetch changelog: ${res.status}`)
       return

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -114,6 +114,8 @@ describe('Utils', () => {
   })
 
   describe('translate', () => {
+    afterEach(() => jest.restoreAllMocks())
+
     it('should translate text using the specified GAS URL', async () => {
       const gasUrl = 'https://example.com/translate'
       const message = 'Hello, world!'

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,4 @@
 import { Utils } from './utils'
-import axios from 'axios'
 
 describe('Utils', () => {
   describe('escape', () => {
@@ -120,15 +119,12 @@ describe('Utils', () => {
       const message = 'Hello, world!'
       const translatedMessage = 'こんにちは、世界！'
 
-      // Mock the axios.post method to return the translated message
-      jest.spyOn(axios, 'post').mockResolvedValueOnce({
-        status: 200,
-        data: {
-          response: {
-            result: translatedMessage,
-          },
-        },
-      })
+      // Mock the fetch method to return the translated message
+      jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ response: { result: translatedMessage } }),
+      } as unknown as Response)
 
       const result = await Utils.translate(gasUrl, message)
       expect(result).toBe(translatedMessage)
@@ -138,10 +134,11 @@ describe('Utils', () => {
       const gasUrl = 'https://example.com/translate'
       const message = 'Hello, world!'
 
-      // Mock the axios.post method to return an error response
-      jest.spyOn(axios, 'post').mockResolvedValueOnce({
+      // Mock the fetch method to return an error response
+      jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: false,
         status: 500,
-      })
+      } as unknown as Response)
 
       const result = await Utils.translate(gasUrl, message)
       expect(result).toBeNull()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,26 +123,33 @@ export const Utils = {
   ): Promise<string | null> {
     const logger = Logger.configure('Utils.translate')
 
-    const res = await fetch(gasUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-      },
-      body: JSON.stringify({
-        before,
-        after,
-        text: message,
-        mode: 'html',
-      }),
-    })
+    try {
+      const res = await fetch(gasUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({
+          before,
+          after,
+          text: message,
+          mode: 'html',
+        }),
+      })
 
-    if (!res.ok) {
-      logger.warn(`❌ メッセージの翻訳に失敗しました：${res.status}`)
+      if (!res.ok) {
+        logger.warn(`❌ メッセージの翻訳に失敗しました：${res.status}`)
+        return null
+      }
+
+      const data = (await res.json()) as GasTranslateResponse
+      return data.response.result
+    } catch (error) {
+      logger.warn(
+        `❌ メッセージの翻訳中に例外が発生しました：${(error as Error).message}`
+      )
       return null
     }
-
-    const data = (await res.json()) as GasTranslateResponse
-    return data.response.result
   },
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { Logger } from '@book000/node-utils'
-import axios from 'axios'
 
 interface GasTranslateResponse {
   response: {
@@ -124,30 +123,26 @@ export const Utils = {
   ): Promise<string | null> {
     const logger = Logger.configure('Utils.translate')
 
-    // Google Apps Scriptサービスに翻訳リクエストを送信
-    const response = await axios.post<GasTranslateResponse>(
-      gasUrl,
-      {
+    const res = await fetch(gasUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: JSON.stringify({
         before,
         after,
         text: message,
         mode: 'html',
-      },
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-      }
-    )
+      }),
+    })
 
-    // レスポンスのステータスに応じて、翻訳が成功したかどうかを確認
-    if (response.status !== 200) {
-      logger.warn(`❌ メッセージの翻訳に失敗しました：${response.status}`)
+    if (!res.ok) {
+      logger.warn(`❌ メッセージの翻訳に失敗しました：${res.status}`)
       return null
     }
 
-    // レスポンスから翻訳されたメッセージを返す
-    return response.data.response.result
+    const data = (await res.json()) as GasTranslateResponse
+    return data.response.result
   },
 }


### PR DESCRIPTION
fix book000/book000#102

axiosへの依存を削除し、ネイティブ fetch API に移行しました。

## 変更内容
- `axios` 依存を削除
- `fetch` API を使用するように変更
- 非 2xx レスポンスに対するエラーハンドリングを追加