### PR TITLE
fix: TypeScript v6 対応のため tsconfig.json を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "rootDir": "./src",
     "outDir": "./dist",
@@ -23,10 +21,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "types": ["node", "jest"]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "Node",
     "lib": ["ESNext", "esnext.AsyncIterable"],
+    "rootDir": "./src",
     "outDir": "./dist",
     "removeComments": true,
     "esModuleInterop": true,
@@ -25,7 +27,8 @@
     "newLine": "LF",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

Renovate PR #1953 (`chore(deps): update dependency typescript to v6`) が以下のエラーで失敗していたため、`tsconfig.json` を TypeScript v6 に対応させました。

本 PR の変更は **TypeScript v5.9.3 (現行) と v6 の両方でコンパイルが通る** ことを確認済みです。

### 修正した TypeScript v6 エラー

| エラーコード | 内容 | 対応 |
|---|---|---|
| `TS5107` | `moduleResolution=Node` (node10 相当) が deprecated | `moduleResolution` を削除 (`module: "commonjs"` に対するデフォルト解決を使用) |
| `TS5101` | `baseUrl` が deprecated | `baseUrl: "."` を削除 (`paths` は TypeScript v4.1 以降 `baseUrl` なしで動作) |
| `TS5011` | `rootDir` が未設定 | `rootDir: "./src"` を追加 |
| `TS2591` / `TS2593` | `process`, `fetch`, `describe` 等のグローバル型が未解決 | `types: ["node", "jest"]` を追加 |

### 変更内容

`tsconfig.json` の `compilerOptions` を以下のように変更:

```diff
 {
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
     "lib": ["ESNext", "esnext.AsyncIterable"],
+    "rootDir": "./src",
     "outDir": "./dist",
     ...
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
-    }
+      "@/*": ["./src/*"]
+    },
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*"]
 }
```

### 動作確認

TypeScript v5.9.3 と v6.0.3 の両方でローカル動作確認済み:

- `tsc --noEmit` が **エラーなし** で通過 (v5.9.3 / v6.0.3 両方)
- `jest` のテスト **16 件すべて通過**
- `eslint` が **エラーなし** で通過

### 備考

- `package.json` の TypeScript バージョン変更は Renovate PR #1953 の担当のため、本 PR では変更しない
- `"types": ["node", "jest"]` の追加により、今後 `@types/*` パッケージを追加する際は `types` 配列への明示的な追記が必要になる点に注意
- `ignoreDeprecations: "6.0"` は TypeScript v5.x では無効な値のため使用せず、deprecated オプションを直接削除するアプローチを採用