### PR TITLE
fix(lint): eslint-plugin-unicorn の name-replacements/no-unreadable-for-of-expression 違反を解消

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface ConfigInterface {
   }
 }
 
-export class Configuration extends ConfigFramework<ConfigInterface> {
+export class Config extends ConfigFramework<ConfigInterface> {
   protected validates(): Record<string, (config: ConfigInterface) => boolean> {
     return {
       'discord is required': (config) => !!config.discord,

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1,7 +1,7 @@
-import { Configuration } from './config'
+import { Config } from './config'
 import { setInterval } from 'node:timers/promises'
 import { Notified } from './notified'
-import { Utils } from './utils'
+import { Utilities } from './utilities'
 import { Discord, DiscordEmbed, Logger } from '@book000/node-utils'
 import { parse, isValid } from 'date-fns'
 
@@ -20,10 +20,10 @@ export class Crawler {
   // Oct 19, 2023
   private readonly dateFormat = 'MMM d, yyyy'
 
-  private config: Configuration
+  private config: Config
   private readonly controller: AbortController = new AbortController()
 
-  constructor(config: Configuration) {
+  constructor(config: Config) {
     this.config = config
   }
 
@@ -31,10 +31,11 @@ export class Crawler {
     try {
       await this.run()
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const _ of setInterval(1000 * 60 * 60, null, {
+      const interval = setInterval(1000 * 60 * 60, null, {
         signal: this.controller.signal,
-      })) {
+      })
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of interval) {
         await this.run()
       }
     } catch (error) {
@@ -53,18 +54,18 @@ export class Crawler {
     const logger = Logger.configure('Crawler.run')
     logger.info('🔍 Fetching changelog')
 
-    let res: Response
+    let response: Response
     try {
-      res = await fetch(this.url)
+      response = await fetch(this.url)
     } catch (error) {
       logger.error(`❌ Failed to fetch changelog: ${(error as Error).message}`)
       return
     }
-    if (!res.ok) {
-      logger.error(`❌ Failed to fetch changelog: ${res.status}`)
+    if (!response.ok) {
+      logger.error(`❌ Failed to fetch changelog: ${response.status}`)
       return
     }
-    const body = await res.text()
+    const body = await response.text()
     if (!body) {
       logger.error('❌ Failed to fetch changelog')
       return
@@ -209,12 +210,12 @@ export class Crawler {
       return null
     }
 
-    const escapedText = Utils.escape(text)
-    const translatedText = await Utils.translate(gasUrl, escapedText)
+    const escapedText = Utilities.escape(text)
+    const translatedText = await Utilities.translate(gasUrl, escapedText)
     if (!translatedText) {
       return null
     }
-    const unescapedText = Utils.unescape(translatedText)
+    const unescapedText = Utilities.unescape(translatedText)
     return unescapedText
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 import { Crawler } from './crawler'
 
 async function main() {
   const logger = Logger.configure('main')
-  const config = new Configuration('data/config.json')
+  const config = new Config('data/config.json')
   config.load()
   if (!config.validate()) {
     logger.error('❌ Configuration is invalid')

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -1,10 +1,10 @@
-import { Utils } from './utils'
+import { Utilities } from './utilities'
 
-describe('Utils', () => {
+describe('Utilities', () => {
   describe('escape', () => {
     it('should escape markdown links', () => {
       const text = 'Check out this link: <https://example.com>'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         'Check out this link: <span translate="no" data-type="url">https://example.com</span>'
       )
@@ -12,7 +12,7 @@ describe('Utils', () => {
 
     it('should escape code blocks', () => {
       const text = '```console.log("Hello, world!");```'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         '<span translate="no" data-type="code-block">console.log("Hello, world!");</span>'
       )
@@ -20,7 +20,7 @@ describe('Utils', () => {
 
     it('should escape inline code', () => {
       const text = '`escape`'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         '<span translate="no" data-type="code">escape</span>'
       )
@@ -28,7 +28,7 @@ describe('Utils', () => {
 
     it('should escape italic and bold formatting', () => {
       const text = '*italic* and **bold**'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         '<span translate="no" data-type="strong-or-italic">*</span>italic<span translate="no" data-type="strong-or-italic">*</span> and <span translate="no" data-type="strong-or-italic">**</span>bold<span translate="no" data-type="strong-or-italic">**</span>'
       )
@@ -36,7 +36,7 @@ describe('Utils', () => {
 
     it('should escape discord formatting', () => {
       const text = 'Check out this channel: <#123456789012345678>'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         'Check out this channel: <span translate="no" data-type="formatting"><#123456789012345678></span>'
       )
@@ -44,7 +44,7 @@ describe('Utils', () => {
 
     it('should escape custom emojis', () => {
       const text = 'Check out this emoji: <:name:123456789012345678>'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         'Check out this emoji: <span translate="no" data-type="formatting"><:name:123456789012345678></span>'
       )
@@ -52,7 +52,7 @@ describe('Utils', () => {
 
     it('should escape user mentions', () => {
       const text = 'Mentioning a user: <@123456789012345678>'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         'Mentioning a user: <span translate="no" data-type="formatting"><@123456789012345678></span>'
       )
@@ -63,34 +63,34 @@ describe('Utils', () => {
     it('should unescape markdown links', () => {
       const text =
         'Check out this link: <span translate="no" data-type="url">https://example.com</span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('Check out this link: <https://example.com>')
     })
 
     it('should unescape code blocks', () => {
       const text =
         '<span translate="no" data-type="code-block">console.log("Hello, world!");</span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('```console.log("Hello, world!");```')
     })
 
     it('should unescape inline code', () => {
       const text = '<span translate="no" data-type="code">escape</span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('`escape`')
     })
 
     it('should unescape italic and bold formatting', () => {
       const text =
         '<span translate="no" data-type="strong-or-italic">*</span>italic<span translate="no" data-type="strong-or-italic">*</span> and <span translate="no" data-type="strong-or-italic">**</span>bold<span translate="no" data-type="strong-or-italic">**</span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('*italic* and **bold**')
     })
 
     it('should unescape discord formatting', () => {
       const text =
         'Check out this channel: <span translate="no" data-type="formatting"><#123456789012345678></span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe(
         'Check out this channel: <#123456789012345678>'
       )
@@ -99,7 +99,7 @@ describe('Utils', () => {
     it('should unescape custom emojis', () => {
       const text =
         'Check out this emoji: <span translate="no" data-type="formatting"><:name:123456789012345678></span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe(
         'Check out this emoji: <:name:123456789012345678>'
       )
@@ -108,7 +108,7 @@ describe('Utils', () => {
     it('should unescape user mentions', () => {
       const text =
         'Mentioning a user: <span translate="no" data-type="formatting"><@123456789012345678></span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('Mentioning a user: <@123456789012345678>')
     })
   })
@@ -128,7 +128,7 @@ describe('Utils', () => {
           Promise.resolve({ response: { result: translatedMessage } }),
       } as unknown as Response)
 
-      const result = await Utils.translate(gasUrl, message)
+      const result = await Utilities.translate(gasUrl, message)
       expect(result).toBe(translatedMessage)
     })
 
@@ -142,7 +142,7 @@ describe('Utils', () => {
         status: 500,
       } as unknown as Response)
 
-      const result = await Utils.translate(gasUrl, message)
+      const result = await Utilities.translate(gasUrl, message)
       expect(result).toBeNull()
     })
   })

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -6,7 +6,7 @@ interface GasTranslateResponse {
   }
 }
 
-export const Utils = {
+export const Utilities = {
   /**
    * テキストをエスケープするメソッド。MarkdownおよびDiscordのフォーマットをエスケープします。
    *
@@ -121,10 +121,10 @@ export const Utils = {
     before = 'en',
     after = 'ja'
   ): Promise<string | null> {
-    const logger = Logger.configure('Utils.translate')
+    const logger = Logger.configure('Utilities.translate')
 
     try {
-      const res = await fetch(gasUrl, {
+      const response = await fetch(gasUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -138,12 +138,12 @@ export const Utils = {
         }),
       })
 
-      if (!res.ok) {
-        logger.warn(`❌ メッセージの翻訳に失敗しました：${res.status}`)
+      if (!response.ok) {
+        logger.warn(`❌ メッセージの翻訳に失敗しました：${response.status}`)
         return null
       }
 
-      const data = (await res.json()) as GasTranslateResponse
+      const data = (await response.json()) as GasTranslateResponse
       return data.response.result
     } catch (error) {
       logger.warn(


### PR DESCRIPTION
## 概要

Renovate PR #2134（`@book000/eslint-config` 1.15.4 -> 1.15.44）の適用先に、新しい `eslint-plugin-unicorn` (71.1.0) が検出する既存コードの命名・構文違反があり、`lint:eslint` が失敗していました。本 PR はその違反を解消します。

## 変更内容

- `unicorn/name-replacements`
  - `Configuration` -> `Config`（`src/config.ts`, `src/crawler.ts`, `src/main.ts`）
  - `Utils` -> `Utilities`（`src/crawler.ts`, `src/utils.ts` -> `src/utilities.ts`, `src/utils.test.ts` -> `src/utilities.test.ts`）
  - `res` -> `response`（`src/crawler.ts`, `src/utilities.ts`）
- `unicorn/no-unreadable-for-of-expression`
  - `src/crawler.ts` の `for await (const _ of setInterval(...))` のループヘッダーから呼び出し式をローカル変数に切り出し

挙動の変更はありません。`package.json`/`pnpm-lock.yaml` の `@book000/eslint-config` バージョン自体はこの PR には含めていません（Renovate PR #2134 側で更新されます）。

## 検証

ローカルで `@book000/eslint-config` 1.15.4（現行）・1.15.44（#2134 の目標）の両方で確認済み:

- `pnpm run lint`（prettier + eslint + tsc）: クリーン
- `pnpm test`: 16/16 pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)