### PR TITLE
fix(lint): resolve unicorn/no-unreadable-for-of-expression, bump @book000/eslint-config to 1.16.3

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -31,10 +31,11 @@ export class Crawler {
     try {
       await this.run()
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const _ of setInterval(1000 * 60 * 60, null, {
+      const interval = setInterval(1000 * 60 * 60, null, {
         signal: this.controller.signal,
-      })) {
+      })
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of interval) {
         await this.run()
       }
     } catch (error) {


### PR DESCRIPTION
## 背景

Renovate PR #2134 (`@book000/eslint-config` 1.15.4 -> 1.16.1) の CI が `lint:eslint` で失敗している。原因は `src/crawler.ts` の `for await (const _ of setInterval(...))` ループヘッダーで、`unicorn/no-unreadable-for-of-expression` が新たに検出されたため。

なお、Renovate PR が提案する 1.16.1 は依存関係の現行性チェックの結果、latest の 1.16.3 に対して未説明のギャップがあると判定されたため、本 PR では 1.16.3 まで引き上げている。

## 変更内容

- `src/crawler.ts`: `setInterval(...)` の呼び出しをループヘッダーの外に出し、ローカル変数に代入してから `for await` で参照するよう変更（挙動は変わらない）
- `package.json` / `pnpm-lock.yaml`: `@book000/eslint-config` を 1.16.3 に更新

## 確認

- `pnpm run lint`（prettier + eslint + tsc）: 問題なし
- `pnpm test`: 16/16 パス